### PR TITLE
exclude some files from final AK3 zip

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -207,6 +207,9 @@ if ! make O=out $arch_opts $make_opts $host_make_opts "$defconfig"; then
     exit 2
 fi
 msg "Begin building kernel..."
+
+make O=out $arch_opts $make_opts $host_make_opts -j"$(nproc --all)" prepare
+
 if ! make O=out $arch_opts $make_opts $host_make_opts -j"$(nproc --all)"; then
     err "Failed building kernel, probably the toolchain is not compatible with the kernel, or kernel source problem"
     exit 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -175,7 +175,7 @@ if [[ $arch = "arm64" ]]; then
             make_opts="CC=clang"
             host_make_opts="HOSTCC=clang HOSTCXX=clang++"
         else
-            make_opts="CC=clang LD=ld.lld NM=llvm-nm AR=llvm-ar STRIP=llvm-strip OBJCOPY=llvm-objcopy"
+            make_opts="CC=clang LD=ld.lld NM=llvm-nm STRIP=llvm-strip OBJCOPY=llvm-objcopy"
             make_opts+=" OBJDUMP=llvm-objdump READELF=llvm-readelf LLVM_IAS=1"
             host_make_opts="HOSTCC=clang HOSTCXX=clang++ HOSTLD=ld.lld HOSTAR=llvm-ar"
         fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -218,7 +218,7 @@ if [[ -e "$workdir"/"$zipper_path" ]]; then
     cp out/arch/"$arch"/boot/"$image" "$workdir"/"$zipper_path"/"$image"
     cd "$workdir"/"$zipper_path" || exit 127
     rm -rf .git
-    zip -r9 "$zip_filename" . || exit 127
+    zip -r9 "$zip_filename" . -x .gitignore README.md || exit 127
     set_output outfile "$workdir"/"$zipper_path"/"$zip_filename"
     cd "$workdir" || exit 127
     exit 0


### PR DESCRIPTION
.gitignore and README.md can be ignored while making the final zip
but keeping the LICENSE as instructed by @osm0sis
"The LICENSE file must remain in the final zip to comply with licenses for binary redistribution and the license of the AK3 scripts."

Signed-off-by: nit-in <nit_in@live.com>